### PR TITLE
Simplify Loudred Discord Commands

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/template.md
@@ -12,4 +12,4 @@
 
 ## Testing
 
-- [ ] Runbook tested
+- [ ] All Runbook tasks passed

--- a/.github/PULL_REQUEST_TEMPLATE/template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/template.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- Summarize what your PR does here -->
+
+## Public-facing changes
+
+<!-- List any changes that might effect how end-users use this bot (changes to commands, new startup options, etc...). You don't have to go in-depth, but try to be comprehensive! -->
+
+## Internal changes
+
+<!-- List any changes to the internal APIs that may effect how developers work on this bot (i.e. new methods on the botWrapper, file reorganization, etc...). You don't have to list EVERY change (that's what code review is for!) but try to give a broad overview of these changes and your reasons for making them. -->
+
+## Testing
+
+- [ ] Runbook tested

--- a/.github/PULL_REQUEST_TEMPLATE/template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/template.md
@@ -10,7 +10,7 @@
 
 <!-- List any changes to the internal APIs that may effect how developers work on this bot (i.e. new methods on the botWrapper, file reorganization, etc...). You don't have to list EVERY change (that's what code review is for!) but try to give a broad overview of these changes and your reasons for making them. -->
 
-## Testing
+## Housekeeping
 
 - [ ] All Runbook tasks passed
 - [ ] Version bumped? _(if not, please explain)_

--- a/.github/PULL_REQUEST_TEMPLATE/template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/template.md
@@ -13,3 +13,4 @@
 ## Testing
 
 - [ ] All Runbook tasks passed
+- [ ] Version bumped? _(if not, please explain)_

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,51 @@
+# Loudred Runbook
+
+Eventually, I'd like to get unit tests set up for Loudred. However, a lot of tasks involve sending data through Discord, which can't be unit-tested easily or effectively. This document is to outline common tasks and edge-cases Loudred should be able to perform. Try running through them before merging in any new changes, especially if you're touching the streams or the commands!
+
+~reccanti 8/27/2020
+
+## Setup
+
+1. Set Mac's output audio device to Blackhole
+2. Set Discord's output device to MacBook Pro Speakers
+3. Start playing a Youtube video or some media
+
+## Happy Path
+
+1. Perform steps in "Setup"
+2. Type `@loudred {PLAY} {channelname}`
+3. You should hear the audio from the Youtube Video
+
+## Join Without Audio
+
+1. Perform the steps in "Setup"
+2. Type `@loudred {JOIN} {channelname}`
+3. Loudred should appear in the channel, but not be playing any audio
+
+## Starting Audio In Channel
+
+1. Perform the steps in "Setup" and "Join Without Audio"
+2. Type `@loudred {PLAY} {channelname}`
+3. Audio should begin playing
+
+## Silencing Audio
+
+1. Perform the steps in "Setup" and "Happy Path"
+2. Type `@loudred {SILENCE} {channelname}`
+3. You should no longer hear audio from the YouTube Video
+4. Type `@loudred {PLAY} {channelname}`
+5. You should hear audio from the video again
+
+## Leaving a Voice Chat
+
+1. Perform the steps in "Setup" and "Happy Path"
+2. Type `@loudred {LEAVE} {channelname}`
+3. Loudred should leave the voice channel
+4. Type `@loudred {PLAY} {channelname}`
+5. Loudres should play audio again
+
+## Stopping the Client
+
+1. Perform the steps in "Setup" and "Happy Path"
+2. Kill the server (ctrl+c)
+3. Loudred should remove itself from the channels it was in.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -49,3 +49,15 @@ Eventually, I'd like to get unit tests set up for Loudred. However, a lot of tas
 1. Perform the steps in "Setup" and "Happy Path"
 2. Kill the server (ctrl+c)
 3. Loudred should remove itself from the channels it was in.
+
+## Listing Commands
+
+1. Type just `@loudred`
+2. You should see a list of commands Loudred can use
+3. Type `@loudred {HELP}`
+4. You should see the same list
+
+## Listing Voice Channels
+
+1. Type `@loudred {LIST}`
+2. You should see a list of all the voice channels in the current server

--- a/config.copy.js
+++ b/config.copy.js
@@ -43,16 +43,6 @@ const COMMANDS = {
     args: ["channel"],
     description: "Stop playing audio in the specified channel",
   },
-  ACTIVATE: {
-    name: "IChooseYou",
-    args: [],
-    description: "Start listening for commands on this server",
-  },
-  DEACTIVATE: {
-    name: "RunAway",
-    args: [],
-    description: "Stop listening for commands on this server",
-  },
   INFO: {
     name: "Stats",
     args: [],
@@ -72,8 +62,6 @@ const MESSAGES = {
     );
     return [firstLine, ...commandDescriptions].join("\n");
   },
-  LEAVE: "_wild_ LOUDRED _ran away_",
-  INACTIVE: "LOUDRED _began to nap!_",
   LIST(channels) {
     const firstLine =
       "Loudred! Loud! _(Here's a list of the voice channels I can join)_";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loudred",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "A discord bot that streams audio from a given source. (Hopefully this will solve some of the issues around streaming audio on MacOS, but we'll see)",
   "main": "index.js",
   "scripts": {

--- a/src/discordBotWrapper.js
+++ b/src/discordBotWrapper.js
@@ -13,12 +13,6 @@
  */
 module.exports = class BotWrapper {
   /**
-   * A list servers the bot is currently active in
-   * Set<Server>
-   */
-  #servers = new Set();
-
-  /**
    * A list of channels the bot is active in
    * Map<Channel, { Server, Connection, Dispatcher, Volume }>
    */
@@ -40,28 +34,6 @@ module.exports = class BotWrapper {
   }
 
   /**
-   * Start keeping track of messages from this server
-   */
-  activate(server) {
-    this.#servers.add(server);
-  }
-
-  /**
-   * Stop keeping track of the server
-   */
-  deactivate(server) {
-    if (this.#servers.has(server)) {
-      // cleanup channels before we stop listening
-      this.#channels.forEach((channelInfo, channel) => {
-        if (channelInfo.server === server) {
-          this.leave(channel);
-        }
-      });
-      this.#servers.delete(server);
-    }
-  }
-
-  /**
    * Return all the voice channels Loudred can join
    */
   getVoiceChannels(server) {
@@ -72,10 +44,9 @@ module.exports = class BotWrapper {
    * deactivate all servers. Give the user a callback
    * so they can send any messages
    */
-  deactivateAll(cb) {
-    this.#servers.forEach((server) => {
-      cb(server);
-      this.deactivate(server);
+  deactivateAll() {
+    this.#channels.forEach((channel) => {
+      this.leave(channel);
     });
   }
 
@@ -84,13 +55,12 @@ module.exports = class BotWrapper {
    * accepting messages from this server
    */
   async join(voiceChannel) {
-    if (this.#servers.has(voiceChannel.guild)) {
-      const connection = await voiceChannel.join();
-      this.#channels.set(voiceChannel, {
-        server: voiceChannel.guild,
-        connection,
-      });
-    }
+    // if (this.#servers.has(voiceChannel.guild)) {
+    const connection = await voiceChannel.join();
+    this.#channels.set(voiceChannel, {
+      server: voiceChannel.guild,
+      connection,
+    });
   }
 
   /**
@@ -111,9 +81,9 @@ module.exports = class BotWrapper {
   /**
    * If we're in the channel, start streaming audio to it
    */
-  play(voiceChannel, stream) {
+  async play(voiceChannel, stream) {
     if (!this.#channels.has(voiceChannel)) {
-      return;
+      await this.join(voiceChannel);
     }
     const info = this.#channels.get(voiceChannel);
     // if we don't have a dispatcher that's playing audio,
@@ -122,10 +92,6 @@ module.exports = class BotWrapper {
       const dispatcher = info.connection.play(stream);
       const volume = dispatcher.volume;
       this.#channels.set(voiceChannel, { ...info, dispatcher, volume });
-    }
-    // otherwise just unpause the current dispatcher
-    else if (info.volume) {
-      info.dispatcher.setVolume(info.volume);
     }
   }
 
@@ -159,6 +125,17 @@ module.exports = class BotWrapper {
     }
   }
 
+  unSilence(voiceChannel) {
+    if (!this.#channels.has(voiceChannel)) {
+      return;
+    }
+    const info = this.#channels.get(voiceChannel);
+    // otherwise just unpause the current dispatcher
+    if (info.volume) {
+      info.dispatcher.setVolume(info.volume);
+    }
+  }
+
   /**
    * Sets the Status of the bot
    */
@@ -171,7 +148,7 @@ module.exports = class BotWrapper {
    * joined the server.
    */
   async sendMessage(channel, message) {
-    if (channel.type === "text" && this.#servers.has(channel.guild)) {
+    if (channel.type === "text") {
       await channel.send(message);
     }
   }

--- a/src/discordBotWrapper.js
+++ b/src/discordBotWrapper.js
@@ -1,16 +1,7 @@
 /**
  * Wrapper for our Discord Bot. Used to abstract behavior
- *
- * Methods we need to implement
- * - Help (guild) -> Print a list of commands
- * - List (guild) ->
- * - Activate (guild) -> join server
- * - Deactivate (guild) -> join server
- * - Join (channel) -> join a voice channel
- * - Leave (channel) -> leave a voice channel
- * - Play (channel) -> start sharing audio in a voice channel
- * - Silence (channel) -> stop sharing audio in a voice channel
  */
+
 module.exports = class BotWrapper {
   /**
    * A list of channels the bot is active in
@@ -41,13 +32,11 @@ module.exports = class BotWrapper {
   }
 
   /**
-   * deactivate all servers. Give the user a callback
-   * so they can send any messages
+   * Return a list of all the voice channels the bot is
+   * currently active in
    */
-  deactivateAll() {
-    this.#channels.forEach((channel) => {
-      this.leave(channel);
-    });
+  getActiveVoiceChannels() {
+    return Array.from(this.#channels.keys());
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -233,7 +233,9 @@ async function setup() {
      */
     process.on("SIGINT", async () => {
       sm.stop();
-      bot.deactivateAll();
+      bot.getActiveVoiceChannels().forEach((channel) => {
+        bot.leave(channel);
+      });
       await bot.setStatus("idle");
     });
   });

--- a/src/index.js
+++ b/src/index.js
@@ -196,7 +196,6 @@ async function setup() {
 
     client.on("message", async (message) => {
       const action = parseBotMessage(message);
-      console.log(action.type);
 
       if (action.type === "list") {
         const { server, channel } = action;

--- a/src/index.js
+++ b/src/index.js
@@ -120,6 +120,10 @@ async function setup() {
        * In the future, I may want to support commands that
        * include spaces
        * ~reccanti 8/22/2020
+       *
+       * @UPDATE Commands still can't include spaces,
+       * but arguments can!
+       * ~reccanti 8/28/2020
        */
       // const messageArgs = message.content.split(" ");
 

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,24 @@ const getAudioDeviceByName = (name) =>
   portAudio.getDevices().find((device) => device.name === name);
 
 /**
+ * Parses our message string and breaks it down into its components.
+ * Messages are in the format:
+ *
+ * <botId> <command> <argument>
+ *
+ * So this breaks it down into an object in the format
+ * { botId, command, argument }
+ */
+const parseMessageString = (content) => {
+  const [id, command = null, ...args] = content.split(" ");
+  return {
+    id,
+    command,
+    arg: args.length > 0 ? args.join(" ") : null,
+  };
+};
+
+/**
  * This is where we set up and run our application. It can be roughly broken
  * down into the following stages:
  *
@@ -103,17 +121,20 @@ async function setup() {
        * include spaces
        * ~reccanti 8/22/2020
        */
-      const messageArgs = message.content.split(" ");
+      // const messageArgs = message.content.split(" ");
+
+      const contents = parseMessageString(message.content);
+
       // help - Display a list of commands
-      if (messageArgs[1] === COMMANDS.HELP) {
+      if (contents.command === COMMANDS.HELP) {
         return {
           ...baseAction,
           type: "help",
         };
       }
       // join - join a voice channel with the given name
-      else if (messageArgs[1] === COMMANDS.JOIN.name && messageArgs[2]) {
-        const voiceChannel = getVoiceChannelByName(server, messageArgs[2]);
+      else if (contents.command === COMMANDS.JOIN.name && contents.arg) {
+        const voiceChannel = getVoiceChannelByName(server, contents.arg);
         if (!voiceChannel) {
           return baseAction;
         }
@@ -124,8 +145,8 @@ async function setup() {
         };
       }
       // leave - leave a voice channel with the given name
-      else if (messageArgs[1] === COMMANDS.LEAVE.name && messageArgs[2]) {
-        const voiceChannel = getVoiceChannelByName(server, messageArgs[2]);
+      else if (contents.command === COMMANDS.LEAVE.name && contents.arg) {
+        const voiceChannel = getVoiceChannelByName(server, contents.arg);
         if (!voiceChannel) {
           return baseAction;
         }
@@ -136,8 +157,8 @@ async function setup() {
         };
       }
       // play - start playing audio in the specified channel
-      else if (messageArgs[1] === COMMANDS.PLAY.name && messageArgs[2]) {
-        const voiceChannel = getVoiceChannelByName(server, messageArgs[2]);
+      else if (contents.command === COMMANDS.PLAY.name && contents.arg) {
+        const voiceChannel = getVoiceChannelByName(server, contents.arg);
         if (!voiceChannel) {
           return baseAction;
         }
@@ -148,8 +169,8 @@ async function setup() {
         };
       }
       // silence - stop playing audio in the specified channel
-      else if (messageArgs[1] === COMMANDS.SILENCE.name && messageArgs[2]) {
-        const voiceChannel = getVoiceChannelByName(server, messageArgs[2]);
+      else if (contents.command === COMMANDS.SILENCE.name && contents.arg) {
+        const voiceChannel = getVoiceChannelByName(server, contents.arg);
         if (!voiceChannel) {
           return baseAction;
         }
@@ -160,21 +181,21 @@ async function setup() {
         };
       }
       // list - list all the voice channels the bot can join in the server
-      else if (messageArgs[1] === COMMANDS.LIST.name) {
+      else if (contents.command === COMMANDS.LIST.name) {
         return {
           ...baseAction,
           type: "list",
         };
       }
       // activate - start listening to commands on the given server
-      else if (messageArgs[1] === COMMANDS.ACTIVATE.name) {
+      else if (contents.command === COMMANDS.ACTIVATE.name) {
         return {
           ...baseAction,
           type: "activate",
         };
       }
       // deactivate - stop listening for commands on the given server
-      else if (messageArgs[1] === COMMANDS.DEACTIVATE.name) {
+      else if (contents.command === COMMANDS.DEACTIVATE.name) {
         return {
           ...baseAction,
           type: "deactivate",

--- a/src/index.js
+++ b/src/index.js
@@ -184,11 +184,11 @@ async function setup() {
           voiceChannel,
         };
       }
-      // deactivate - stop listening for commands on the given server
-      else if (contents.command === COMMANDS.DEACTIVATE.name) {
+      // list - list the voice channels we can join
+      else if (contents.command === COMMANDS.LIST.name) {
         return {
           ...baseAction,
-          type: "deactivate",
+          type: "list",
         };
       }
       return baseAction;

--- a/src/streamManager.js
+++ b/src/streamManager.js
@@ -51,19 +51,6 @@ class StreamManager {
       .inputFormat("s16le")
       .inputOptions([`-ar ${this.#device.defaultSampleRate}`, `-ac ${2}`]);
 
-    // TEST CODE DELETE LATER
-    // const ao = new portAudio.AudioIO({
-    //   outOptions: {
-    //     channelCount: 2,
-    //     sampleFormat: portAudio.SampleFormat16Bit,
-    //     sampleRate: 44100,
-    //     deviceId: 2,
-    //     closeOnError: false,
-    //   },
-    // });
-    // this.#proc.outputFormat("wav").pipe(ao);
-    // ao.start();
-
     this.#proc.outputFormat("ogg").pipe(pass);
     this.#ai.start();
 

--- a/src/streamManager.js
+++ b/src/streamManager.js
@@ -48,6 +48,9 @@ class StreamManager {
      * Breakdown here: https://stackoverflow.com/a/11990796
      */
     this.#proc = ffmpeg({ source: this.#ai })
+      .on("error", (err) => {
+        console.log(err);
+      })
       .inputFormat("s16le")
       .inputOptions([`-ar ${this.#device.defaultSampleRate}`, `-ac ${2}`]);
 

--- a/src/streamManager.js
+++ b/src/streamManager.js
@@ -49,10 +49,22 @@ class StreamManager {
      */
     this.#proc = ffmpeg({ source: this.#ai })
       .inputFormat("s16le")
-      .inputOptions([`-ar ${this.#device.defaultSampleRate}`, `-ac ${2}`])
-      .outputFormat("ogg");
+      .inputOptions([`-ar ${this.#device.defaultSampleRate}`, `-ac ${2}`]);
 
-    this.#proc.pipe(pass);
+    // TEST CODE DELETE LATER
+    // const ao = new portAudio.AudioIO({
+    //   outOptions: {
+    //     channelCount: 2,
+    //     sampleFormat: portAudio.SampleFormat16Bit,
+    //     sampleRate: 44100,
+    //     deviceId: 2,
+    //     closeOnError: false,
+    //   },
+    // });
+    // this.#proc.outputFormat("wav").pipe(ao);
+    // ao.start();
+
+    this.#proc.outputFormat("ogg").pipe(pass);
     this.#ai.start();
 
     return pass;


### PR DESCRIPTION
## Description

This simplifies the commands needed to get Loudred working on a server and makes some quality-of-life improvements to the botWrapper API. 

## Public-Facing Changes

* The `ACTIVATE` and `DEACTIVATE` commands have been removed. You can issue commands to Loudred as soon as you start the client
* In addition to `@loudred {HELP}`, you can now just call `@loudred` to get a list of commands to use
* You can now join a voice channel while playing audio by using `@loudred {PLAY}`. `@loudred {JOIN}` still exists and can be used to join the channel without playing audio

## Internal Changes

* Added a RUNBOOK.md file that contains a list of tasks for testing Loudred in a Discord server before merging any changes.
* remove the private `#servers` property in `botWrapper.js`, since we no longer need to "activate" loudred on a server before using
* Removed `disconnectAll` command from `botWrapper.js`, since we no longer rely on the private `#servers` property. Instead, you're encouraged to recreate this functionality by iterating over the channels you get from the newly-created `getActiveVoiceChannels` method
* Separated the `play()` method into `play()` and `unsilence()`. The command listener in `index.js` now determines which method to call, rather than having this be an implementation detail in `botWrapper.js`

## Housekeeping

- [X] All Runbook tasks passed
- [X] Version bumped?